### PR TITLE
Allow polygons to be edited after creation.

### DIFF
--- a/frontend/src/js/map/initialize-drawing-manager.js
+++ b/frontend/src/js/map/initialize-drawing-manager.js
@@ -14,6 +14,9 @@ export default function () {
     drawingControlOptions: {
       position: google.maps.ControlPosition.TOP_CENTER,
       drawingModes: ['polygon']
+    },
+    polygonOptions: {
+      editable: true
     }
   });
   drawingManager.setMap(map);


### PR DESCRIPTION
I found it kinda annoying creating polygons for very large areas, only to find that (upon zooming in) I screwed up the drawing a little bit. This change makes the polygons user-editable, which is wonderful for quick tweaks that need to be done.
